### PR TITLE
add missing declaration for etree.indent

### DIFF
--- a/lxml-stubs/etree/__init__.pyi
+++ b/lxml-stubs/etree/__init__.pyi
@@ -798,6 +798,13 @@ def tostring(
     inclusive_ns_prefixes: Any = ...,
 ) -> _AnyStr: ...
 
+def indent(
+    element_or_tree: _ElementOrAnyTree,
+    space: str = ...,
+    *,
+    level: int = ...,
+) -> None: ...
+
 class Error(Exception): ...
 
 class LxmlError(Error):


### PR DESCRIPTION
Add missing declaration for etree.indent, see [api](https://lxml.de/api/lxml.etree-module.html#indent) or [source](https://github.com/lxml/lxml/blob/c742576c105f40fc8b754fcae56fee4aa35840a3/src/lxml/etree.pyx#L3292).
Hopefully, I got the types right.